### PR TITLE
changed the CloudWatch Event Rule (ExportDynamoDBData) schedule to ru…

### DIFF
--- a/src/cft.yaml
+++ b/src/cft.yaml
@@ -338,7 +338,7 @@ Resources:
     Properties:
       Description: "Exports DyanmoDB data to S3"
       Name: ExportDynamoDBData
-      ScheduleExpression: rate(12 hours)
+      ScheduleExpression: rate(1 hour)
       State: ENABLED
       Targets:
         - Arn: !GetAtt ExportDynamoDBDataToS3.Arn


### PR DESCRIPTION
Updated CloudWatch Event Rule schedule in CFN template

*Description of changes:*
Changed the CloudWatch Event Rule (ExportDynamoDBData) schedule to run every 1 hour in CFN template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
